### PR TITLE
Added prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "delete-dts.js": "find ./lib/commonjs -name '*.d.js*' -delete && find ./lib/module -name '*.d.js*' -delete",
     "release": "rm -rf lib && yarn build && release-it",
     "example": "yarn --cwd example",
-    "bootstrap": "yarn install && yarn example"
+    "bootstrap": "yarn install && yarn example",
+    "prepare": "yarn build"
   },
   "dependencies": {
     "@gorhom/portal": "1.0.14",


### PR DESCRIPTION
Added a prepare script to package.json, which runs existing build step automatically whenever someone installs from GitHub. This ensures the lib/ folder and .d.ts declarations are generated, so TypeScript and Metro can resolve @gorhom/bottom-sheet correctly.

Please provide enough information so that others can review your pull request:

## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

